### PR TITLE
Fix UpdateUser body type

### DIFF
--- a/src/users.ts
+++ b/src/users.ts
@@ -107,7 +107,7 @@ export type UpdateUserParams = {
 export type UpdateUserBody = {
   first_name?: string
   last_name?: string
-  type?: UserLoginType
+  type?: UserAccountType
   pmi?: number
   use_pmi?: boolean
   timezone?: string


### PR DESCRIPTION
`type` in `UpdateUserBody` should have `UserAccountType` according to the [Zoom API's definition of userUpdate](https://marketplace.zoom.us/docs/api-reference/zoom-api/methods/#operation/userUpdate) instead of `UserLoginType` (which can be sent in `UpdateUserParams`)

Testing:
Confirmed that running `client.users.UpdateUser(email, {}, { type: 2 })` does in fact set the account type to what we expect.

Notes:
I need this in schoolhouse-world/app#6425 to update user types from Basic -> Licensed



