### PR TITLE
Implement List Past Meeting Instances

### DIFF
--- a/src/meetings.ts
+++ b/src/meetings.ts
@@ -91,7 +91,7 @@ export type ListMeetingsParams = {
 export type ListMeetingsResponse = PaginatedResponse & {
   meetings: Meeting[]
 }
-export type ListPastMeetingsResponse = { meetings: {start_time: string, uuid: string}[] }
+export type ListPastMeetingInstancesResponse = { meetings: { start_time: string; uuid: string }[] }
 export type GetMeetingParams = {
   occurrence_id?: string
 }
@@ -115,10 +115,10 @@ export default function (zoomRequest: ReturnType<typeof request>) {
       params: params,
     })
   }
-  const ListPastMeetings = function (meetingId) {
-    return zoomRequest<ListPastMeetingsResponse>({
-        method: 'GET',
-        path: `/past_meetings/${meetingId}/instances`,
+  const ListPastMeetingInstances = function (meetingId) {
+    return zoomRequest<ListPastMeetingInstancesResponse>({
+      method: 'GET',
+      path: `/past_meetings/${meetingId}/instances`,
     })
   }
   const CreateMeeting = function (userId: string, meeting: Meeting) {
@@ -199,7 +199,7 @@ export default function (zoomRequest: ReturnType<typeof request>) {
 
   return {
     ListMeetings,
-    ListPastMeetings,
+    ListPastMeetingInstances,
     CreateMeeting,
     GetMeeting,
     UpdateMeeting,

--- a/src/meetings.ts
+++ b/src/meetings.ts
@@ -91,6 +91,7 @@ export type ListMeetingsParams = {
 export type ListMeetingsResponse = PaginatedResponse & {
   meetings: Meeting[]
 }
+export type ListPastMeetingsResponse = { meetings: {start_time: string, uuid: string}[] }
 export type GetMeetingParams = {
   occurrence_id?: string
 }
@@ -112,6 +113,12 @@ export default function (zoomRequest: ReturnType<typeof request>) {
       method: 'GET',
       path: `/users/${userId}/meetings`,
       params: params,
+    })
+  }
+  const ListPastMeetings = function (meetingId) {
+    return zoomRequest<ListPastMeetingsResponse>({
+        method: 'GET',
+        path: `/past_meetings/${meetingId}/instances`,
     })
   }
   const CreateMeeting = function (userId: string, meeting: Meeting) {
@@ -192,6 +199,7 @@ export default function (zoomRequest: ReturnType<typeof request>) {
 
   return {
     ListMeetings,
+    ListPastMeetings,
     CreateMeeting,
     GetMeeting,
     UpdateMeeting,

--- a/src/meetings.ts
+++ b/src/meetings.ts
@@ -115,12 +115,6 @@ export default function (zoomRequest: ReturnType<typeof request>) {
       params: params,
     })
   }
-  const ListPastMeetingInstances = function (meetingId) {
-    return zoomRequest<ListPastMeetingInstancesResponse>({
-      method: 'GET',
-      path: `/past_meetings/${meetingId}/instances`,
-    })
-  }
   const CreateMeeting = function (userId: string, meeting: Meeting) {
     return zoomRequest<Meeting>({
       method: 'POST',
@@ -194,6 +188,12 @@ export default function (zoomRequest: ReturnType<typeof request>) {
     return zoomRequest<GetMeetingRecordingsResponse>({
       method: 'GET',
       path: `/meetings/${meetingId}/recordings`,
+    })
+  }
+  const ListPastMeetingInstances = function (meetingId) {
+    return zoomRequest<ListPastMeetingInstancesResponse>({
+      method: 'GET',
+      path: `/past_meetings/${meetingId}/instances`,
     })
   }
 


### PR DESCRIPTION
Implements [this](https://developers.zoom.us/docs/api/rest/reference/zoom-api/methods/#operation/pastMeetings) endpoint.

**Test Plan**
- [x] manually modified my node_modules on the Schoolhouse repo and tested with a script that the the correct UUIDs are returned.
- what's the best way to test this code directly?