### PR TITLE
Add UpdateMeetingSurvey

### DIFF
--- a/src/meetings.ts
+++ b/src/meetings.ts
@@ -106,6 +106,9 @@ export type GetMeetingInvitationResponse = {
   invitation: string
 }
 export type GetMeetingRecordingsResponse = RecordingMeeting
+export type UpdateMeetingSurveyParams = {
+	third_party_survey: string
+}
 
 export default function (zoomRequest: ReturnType<typeof request>) {
   const ListMeetings = function (userId: string, params?: ListMeetingsParams) {
@@ -190,10 +193,17 @@ export default function (zoomRequest: ReturnType<typeof request>) {
       path: `/meetings/${meetingId}/recordings`,
     })
   }
-  const ListPastMeetingInstances = function (meetingId) {
+  const ListPastMeetingInstances = function (meetingId: string) {
     return zoomRequest<ListPastMeetingInstancesResponse>({
       method: 'GET',
       path: `/past_meetings/${meetingId}/instances`,
+    })
+  }
+  const UpdateMeetingSurvey = function (meetingId: string, params: UpdateMeetingSurveyParams) {
+    return zoomRequest<{}>({
+      method: 'PATCH',
+      path: `/meetings/${meetingId}/survey`,
+      body: params,
     })
   }
 
@@ -210,5 +220,6 @@ export default function (zoomRequest: ReturnType<typeof request>) {
     UpdateRegistrantStatus,
     GetMeetingInvitation,
     GetMeetingRecordings,
+	UpdateMeetingSurvey,
   }
 }

--- a/src/meetings.ts
+++ b/src/meetings.ts
@@ -106,7 +106,7 @@ export type GetMeetingInvitationResponse = {
   invitation: string
 }
 export type GetMeetingRecordingsResponse = RecordingMeeting
-export type UpdateMeetingSurveyParams = {
+export type UpdateMeetingSurveyBody = {
 	third_party_survey: string
 }
 
@@ -199,11 +199,11 @@ export default function (zoomRequest: ReturnType<typeof request>) {
       path: `/past_meetings/${meetingId}/instances`,
     })
   }
-  const UpdateMeetingSurvey = function (meetingId: string, params: UpdateMeetingSurveyParams) {
+  const UpdateMeetingSurvey = function (meetingId: string, body: UpdateMeetingSurveyBody) {
     return zoomRequest<{}>({
       method: 'PATCH',
       path: `/meetings/${meetingId}/survey`,
-      body: params,
+      body: body,
     })
   }
 


### PR DESCRIPTION
* Add support for update meeting survey: https://developers.zoom.us/docs/api/rest/reference/zoom-api/methods/#operation/meetingSurveyUpdate
* So far, only support third_party_survey
* i tested this by pointing to it locally and calling it. I joined the zoom room and made sure it opened the link:

![image](https://github.com/user-attachments/assets/51f5d5ff-d5ea-4e4b-a917-63c2d94650b6)
