### PR TITLE
Upgrade to `nodenext` module system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 1.0.3
+- Use `nodenext` for module system
+
 ### 1.0.2
 - Add `UpdateMeetingSurvey`
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,15 @@
 {
   "name": "@schoolhouse/zoomapi",
-  "version": "1.0.2",
+  "version": "1.0.3",
+  "type": "module",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "import": "./lib/index.js"
+    }
+  },
   "description": "NodeJS library for working with the Zoom API.",
   "repository": {
     "type": "git",
@@ -24,7 +31,7 @@
     "prepare": "npm run eslint && npm run clean && npm run build"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=18"
   },
   "dependencies": {
     "jsonwebtoken": "^8.5.1"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,14 @@
-import meetings from './meetings'
-import metrics from './metrics'
-import recordings from './recordings'
-import reports from './reports'
-import users from './users'
-import webinars from './webinars'
-import webhooks from './webhooks'
-import oauth from './oauth'
+import meetings from './meetings.js'
+import metrics from './metrics.js'
+import recordings from './recordings.js'
+import reports from './reports.js'
+import users from './users.js'
+import webinars from './webinars.js'
+import webhooks from './webhooks.js'
+import oauth from './oauth.js'
 
-import { ZoomOptions } from './common'
-import request from './util/request'
+import { ZoomOptions } from './common.js'
+import request from './util/request.js'
 
 export default function (zoomApiOpts: ZoomOptions) {
   const zoomRequest = request(zoomApiOpts)
@@ -25,12 +25,12 @@ export default function (zoomApiOpts: ZoomOptions) {
   }
 }
 
-export * from './common'
-export * from './meetings'
-export * from './metrics'
-export * from './recordings'
-export * from './reports'
-export * from './users'
-export * from './webhooks'
-export * from './webinars'
-export * from './oauth'
+export * from './common.js'
+export * from './meetings.js'
+export * from './metrics.js'
+export * from './recordings.js'
+export * from './reports.js'
+export * from './users.js'
+export * from './webhooks.js'
+export * from './webinars.js'
+export * from './oauth.js'

--- a/src/meetings.ts
+++ b/src/meetings.ts
@@ -1,4 +1,4 @@
-import request from './util/request'
+import request from './util/request.js'
 import {
   PaginatedResponse,
   TrackingField,
@@ -16,7 +16,7 @@ import {
   UpdateRegistrantStatusBody,
   UpdateRegistrantStatusParams,
   RecordingMeeting,
-} from './common'
+} from './common.js'
 
 /**
  * 1 - Instant meeting.

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1,5 +1,5 @@
-import { MetricMeeting, PaginatedResponse } from './common'
-import request from './util/request'
+import { MetricMeeting, PaginatedResponse } from './common.js'
+import request from './util/request.js'
 
 export type GetMetricsMeetingsParams = {
   type?: 'past' | 'pastOne' | 'live'

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -1,5 +1,5 @@
-import { ZoomOptions } from './common'
-import { getServerToServerOAuthToken } from './util/getAuthToken'
+import { ZoomOptions } from './common.js'
+import { getServerToServerOAuthToken } from './util/getAuthToken.js'
 
 export default function (zoomApiOpts: ZoomOptions) {
   const GetServerToServerOAuthToken = async function () {

--- a/src/recordings.ts
+++ b/src/recordings.ts
@@ -1,5 +1,5 @@
-import { RecordingMeeting } from './common'
-import request from './util/request'
+import { RecordingMeeting } from './common.js'
+import request from './util/request.js'
 
 export type GetAccountRecordingsParams = {
   page_size?: number

--- a/src/reports.ts
+++ b/src/reports.ts
@@ -1,5 +1,5 @@
-import { PaginatedResponse } from './common'
-import request from './util/request'
+import { PaginatedResponse } from './common.js'
+import request from './util/request.js'
 
 export type GetMeetingParticipantReportsParams = {
   page_size?: number

--- a/src/users.ts
+++ b/src/users.ts
@@ -1,5 +1,5 @@
-import request from './util/request'
-import { PaginatedResponse } from './common'
+import request from './util/request.js'
+import { PaginatedResponse } from './common.js'
 
 /**
  * 1 - Basic.

--- a/src/util/getAuthToken.ts
+++ b/src/util/getAuthToken.ts
@@ -1,7 +1,7 @@
 import https from 'https'
 import jwt from 'jsonwebtoken'
-import type { ZoomOptions, ZoomJWTOptions, ZoomOAuthOptions, OauthTokenResponse } from '../'
-import ZoomError from './ZoomError'
+import type { ZoomOptions, ZoomJWTOptions, ZoomOAuthOptions, OauthTokenResponse } from '../common.js'
+import ZoomError from './ZoomError.js'
 
 const isJWTOptions = function (zoomApiOpts: ZoomOptions): zoomApiOpts is ZoomJWTOptions {
   return 'apiKey' in zoomApiOpts

--- a/src/util/request.ts
+++ b/src/util/request.ts
@@ -1,7 +1,7 @@
 import https from 'https'
-import getAuthToken from './getAuthToken'
-import { ZoomOptions } from '../'
-import ZoomError from './ZoomError'
+import getAuthToken from './getAuthToken.js'
+import { ZoomOptions } from '../common.js'
+import ZoomError from './ZoomError.js'
 
 const BASE_URL = 'api.zoom.us'
 const API_VERSION = '/v2'

--- a/src/webhooks.ts
+++ b/src/webhooks.ts
@@ -1,6 +1,6 @@
-import { WebinarDetails } from './webinars'
-import { Meeting } from './meetings'
-import { Registrant, ZoomOptions } from './common'
+import { WebinarDetails } from './webinars.js'
+import { Meeting } from './meetings.js'
+import { Registrant, ZoomOptions } from './common.js'
 import { IncomingHttpHeaders } from 'http'
 import crypto from 'crypto'
 

--- a/src/webinars.ts
+++ b/src/webinars.ts
@@ -1,4 +1,4 @@
-import request from './util/request'
+import request from './util/request.js'
 import {
   PaginatedResponse,
   TrackingField,
@@ -16,7 +16,7 @@ import {
   AddRegistrantResponse,
   UpdateRegistrantStatusBody,
   UpdateRegistrantStatusParams,
-} from './common'
+} from './common.js'
 
 /**
  * 5 - Webinar

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
     "esModuleInterop": true,
-    "target": "ES2017",
-    "module": "commonjs",
-    "moduleResolution": "node",
+    "target": "ES2022",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "declaration": true,
     "outDir": "./lib"
   },


### PR DESCRIPTION
@akshitdewan Implemented a [patch](https://github.com/schoolhouse-world/app/pull/14745) for the Schoolhouse-proprietary `zoomapi` library that tries to make it work with the new `run-script`. While this worked in his development environment, I can't get it to work in mine, so I'm going straight to the source and upgrading the module system to `nodenext` such that the compiled source code for this package is ESM-compatible.